### PR TITLE
Lowered the ZF version requirements by getting rid of the PSR7 bridge…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,11 +24,14 @@
     "zendframework/zend-db": "^2.0",
     "symfony/console": "^3.2",
     "psr/http-message": "^1.0",
+    "symfony/yaml": "^3.2",
     "zendframework/zend-view": "^2.0",
-    "zendframework/zend-psr7bridge": "^0.1",
+    "zendframework/zend-http": "^2.0",
     "zendframework/zend-form": "^2.0",
-    "zendframework/zend-i18n": "^2.0",
-    "symfony/yaml": "^3.2"
+    "zendframework/zend-i18n": "^2.0"
   },
+  "suggest": {
+    "zendframework/zend-psr7bridge": "^0.1"
+    },
   "bin": ["bin/magium-configuration"]
 }


### PR DESCRIPTION
…, which requires zend-http ^2.5